### PR TITLE
W6 observability: add API health checks, dashboards/alerts spec, runbooks, failure drills

### DIFF
--- a/Docs/PROFESSIONAL_DAILY_USE_PLAN.md
+++ b/Docs/PROFESSIONAL_DAILY_USE_PLAN.md
@@ -150,10 +150,12 @@ Branch: `feature/professional-w5-stabilization`
 - Performance smoke tests — not run this sprint; flagged as a pre-release follow-up.
 - `Docs/W5_STABILIZATION_CHECKLIST.md` — full results + conditional go/no-go recommendation
 
-### Week 6 - Observability and Runbooks ⬜ NOT STARTED
-- Dashboards and alerts: API error rate, p95 latency, auth failures, push failures, kiosk failures
-- Runbooks: degraded API, S3 outage, push provider outage, emergency rollback
-- Failure simulation drills
+### Week 6 - Observability and Runbooks ✅ COMPLETE
+Branch: `feature/professional-w6-observability`
+- Added `/health` (liveness) and `/health/ready` (DB connectivity) endpoints to the API — there were no health checks at all before this sprint.
+- `Docs/W6_DASHBOARDS_AND_ALERTS.md` — metric definitions and alert thresholds for API error rate, p95 latency, auth failures, push failures, and kiosk interstitial failures, grounded in this codebase's actual logging. No dashboards were actually provisioned (Datadog/Grafana access requires an interactive OAuth grant not available this session) — this is the spec for whoever wires up the chosen backend.
+- `Docs/W6_RUNBOOKS.md` — degraded API, S3 outage, push provider outage, and emergency rollback, all grounded in the real `docker compose` deploy topology (`.github/workflows/deploy.yml`).
+- `Docs/W6_FAILURE_DRILLS.md` — 5 concrete drills to validate the runbooks/alerts actually work; none executed yet (staging-only, not run this sprint).
 
 ## Prioritization Rules
 1. Protect clocking and payroll-adjacent workflows first.

--- a/Docs/W6_DASHBOARDS_AND_ALERTS.md
+++ b/Docs/W6_DASHBOARDS_AND_ALERTS.md
@@ -1,0 +1,103 @@
+# W6 Dashboards & Alerts Spec
+
+**Branch:** `feature/professional-w6-observability` (from `develop`)
+**Plan reference:** `Docs/PROFESSIONAL_DAILY_USE_PLAN.md` — Week 6
+
+## Current state (as found)
+
+Before this sprint, the API had:
+- Plain `ILogger<T>` structured logging via ASP.NET Core's default provider (console/debug sink
+  only) — no external log aggregator, APM, or metrics exporter configured (no Serilog, no
+  Application Insights, no OpenTelemetry, no Datadog agent).
+- No health-check endpoint at all — nothing to point an uptime monitor or load balancer at.
+- No dashboards, alerts, or on-call tooling connected to this repo.
+
+This doc specifies what to build; it does not stand up real dashboards, since this session has no
+authorized connection to an observability backend (Datadog, Grafana, etc. all require an
+interactive OAuth grant this environment can't perform). Treat the queries/thresholds below as the
+spec for whoever wires up the chosen tool.
+
+## What this sprint added
+
+- `ShiftWork.Api/Services/DatabaseHealthCheck.cs` — checks `ShiftWorkContext.Database.CanConnectAsync()`.
+- `GET /health` — liveness probe, no dependency checks (process is up).
+- `GET /health/ready` — readiness probe, runs checks tagged `"ready"` (currently: database).
+- Point your load balancer / uptime monitor at `/health`; point k8s-style readiness probes or an
+  "is the API actually usable" check at `/health/ready`.
+
+## Metrics and alert definitions
+
+Each entry lists: what to track, where the signal comes from today, and the alert threshold to
+start with (tune after a week of real traffic).
+
+### 1. API error rate
+- **Signal:** HTTP 5xx response rate. Every controller in this codebase wraps its body in
+  `try/catch` and returns `StatusCode(500, ...)` with a paired `_logger.LogError(ex, ...)` call
+  (see `BulletinsController`, `DocumentsController`, `SafetyController`, `DailyReportsController`
+  for the v2 modules — same pattern used app-wide).
+- **How to collect:** either scrape ASP.NET Core's built-in `http.server.request.duration` /
+  status-code metrics (available via `Microsoft.Extensions.Diagnostics.Metrics` + an
+  OpenTelemetry exporter — not yet wired), or ingest the structured log stream and count
+  `LogError` occurrences per endpoint.
+- **Alert:** 5xx rate > 2% of requests over 5 minutes → warning; > 5% → page.
+
+### 2. p95 latency
+- **Signal:** request duration, same metrics source as above.
+- **Priority endpoints:** the 4 v2 list endpoints (`GET .../bulletins`, `.../documents`,
+  `.../safety`, `.../{locationId}/daily-reports`) since they're paginated and DB-query-heavy, plus
+  `POST /api/auth/login` and `POST /api/kiosk/*/clock` (clocking is the P0 workflow per
+  `PROFESSIONAL_DAILY_USE_PLAN.md`'s prioritization rules).
+- **Alert:** p95 > 1.5s over 5 minutes on any priority endpoint → warning; > 3s → page.
+
+### 3. Auth failures
+- **Signal:** 401/403 response rate. Two auth schemes are registered in `Program.cs`
+  (`AddJwtBearer` default = Firebase for web, `"ApiJwt"` = mobile) plus
+  `PermissionAuthorizationHandler` for policy checks — a spike here usually means either a token
+  issuer problem (expired signing key, clock skew) or an actual credential-stuffing attempt.
+- **Also watch:** `AddRateLimiter` is configured in `Program.cs:152` — a spike in rate-limit
+  rejections (HTTP 429) alongside 401s is a stronger signal of abuse than either alone.
+- **Alert:** 401/403 rate > 10% of requests over 5 minutes → warning (check for a deploy that
+  rotated a signing key); sudden spike (>3x baseline) → page (possible attack).
+
+### 4. Push notification failures
+- **Signal:** `PushNotificationService` already logs every failure mode with structured context:
+  `LogWarning` for "no device tokens found" (benign — no page), `LogError` with the raw Expo
+  response body on send failure, `LogWarning` per-ticket for individual delivery errors (invalid
+  token, etc.), and a top-level `LogError(ex, "Error sending push notifications")` on exception.
+- **Alert:** any `LogError("Failed to send push notifications...")` occurrence → warning (Expo API
+  itself is degraded); if push failures correlate with a spike in "no device tokens found" alone,
+  that's a mobile-app registration bug, not an outage — don't page on that pattern alone.
+
+### 5. Kiosk interstitial failures
+- **Signal:** the Kiosk RN app's interstitial screen (post-clockout bulletins/safety
+  acknowledgments) already has a 5-second auto-advance fallback on load failure (added in W2 —
+  see `PROFESSIONAL_DAILY_USE_PLAN.md`'s Week 2 summary) so a failure here is silent to the
+  employee by design. That's exactly why it needs server-side visibility: add structured logging
+  to the kiosk-facing endpoints (`GET /bulletins/unread?priority=Urgent`,
+  `GET /people/{personId}/safety/pending`) if not already present, and alert on their error rate
+  specifically, since a client-side silent fallback means no user will ever report this.
+- **Alert:** any sustained error rate (>1% over 15 minutes) on the two kiosk post-clockout
+  endpoints → warning, since safety acknowledgments silently not being surfaced is a compliance
+  risk, not just a UX one.
+
+## Suggested dashboard layout
+
+One dashboard per audience:
+- **API health** — error rate, p95/p99 latency, request volume, `/health` and `/health/ready`
+  status, all split by endpoint group (auth, bulletins, documents, safety, daily-reports, kiosk).
+- **Auth & security** — 401/403 rate, 429 (rate-limit) rate, JWT scheme breakdown (Firebase vs
+  ApiJwt), overlaid with deploy markers (a spike right after a deploy usually means a config/key
+  issue, not an attack).
+- **Notifications** — push send success/failure rate, email send failures (SMTP config is in
+  `CLAUDE.md`'s env var table), broken down by trigger (bulletin publish, safety publish,
+  schedule/shift publish).
+
+## Prerequisites to actually wire this up
+
+1. Pick a backend (Datadog is already listed as an available-but-unauthorized MCP connector for
+   this environment — `claude mcp` / `/mcp` in an interactive session to connect it).
+2. Add an OpenTelemetry exporter (`OpenTelemetry.Extensions.Hosting` +
+   `OpenTelemetry.Instrumentation.AspNetCore`) to `ShiftWork.Api` to get the request-duration/
+   status-code metrics referenced above without hand-rolling counters.
+3. Ship logs somewhere queryable (the current console-only sink means logs only exist in whatever
+   captures stdout — fine for local `dotnet run`, not sufficient for production alerting).

--- a/Docs/W6_FAILURE_DRILLS.md
+++ b/Docs/W6_FAILURE_DRILLS.md
@@ -1,0 +1,99 @@
+# W6 Failure Simulation Drills
+
+**Branch:** `feature/professional-w6-observability` (from `develop`)
+**Plan reference:** `Docs/PROFESSIONAL_DAILY_USE_PLAN.md` — Week 6
+
+Purpose: concrete, repeatable steps to validate the runbooks in `Docs/W6_RUNBOOKS.md` actually
+work, and that the alerts in `Docs/W6_DASHBOARDS_AND_ALERTS.md` actually fire. Run these against a
+staging environment, never production. Each drill lists the injection method, the expected
+detection signal, and which runbook it validates.
+
+## Drill 1 — Database unreachable
+
+**Inject:** point `DB_CONNECTION_STRING` at an unreachable host, or firewall off the SQL Server
+port from the API container, then restart the `api` service.
+
+**Expect:**
+- `GET /health` still returns healthy (liveness only checks the process is up — no DB dependency).
+- `GET /health/ready` returns unhealthy within the health check's evaluation window, surfacing
+  `DatabaseHealthCheck`'s `"Cannot connect to the database."` message.
+- Any endpoint touching data returns 500 with a paired `LogError` in the API logs.
+
+**Validates:** Runbook 1, step 1–2. **Fix and confirm:** restore connectivity, re-check
+`/health/ready` flips back to healthy without a restart (health checks re-evaluate on each poll).
+
+## Drill 2 — S3 unreachable / bad credentials
+
+**Inject:** temporarily set `AWS_S3_BUCKET_NAME` to a nonexistent bucket name (with
+`AWS_S3_AUTO_CREATE` left at its normal staging value), or revoke the IAM role's S3 permissions.
+
+**Expect:**
+- Document upload (`InitiateUploadAsync`/`ConfirmUploadAsync` flow) and daily-report photo upload
+  fail with an `AmazonS3Exception` logged by `AwsS3Service`.
+- Bulletins, safety text content, and clock in/out continue to work normally — confirming the
+  blast radius really is limited to file access, not the whole API.
+
+**Validates:** Runbook 2, steps 1–2. **Fix and confirm:** restore the correct bucket
+name/credentials, re-upload a test document successfully.
+
+## Drill 3 — Push provider outage
+
+**Inject:** point `EXPO_PUSH_API_URL` at an unreachable or 500-always endpoint, then publish a
+test bulletin with `Status: Published` to a location with at least one registered device token.
+
+**Expect:**
+- `PushNotificationService` logs `LogError("Failed to send push notifications. Status: {Status},
+  Error: {Error}", ...)`.
+- The bulletin itself is still created and visible in-app (`GetBulletinsAsync`/`GetUnreadAsync`
+  unaffected) — only the push alert is missing.
+- No exception propagates to the caller — `CreateAsync` in `BulletinService` wraps
+  `SendBulletinPushAsync` in try/catch, so bulletin creation itself must return 200/201 even
+  when push fails. If this drill causes bulletin creation to fail outright, that's a regression in
+  the push failure isolation, not expected behavior — fix it as a bug, not just document it.
+
+**Validates:** Runbook 3, steps 1 and 4. **Fix and confirm:** restore `EXPO_PUSH_API_URL`, publish
+another test bulletin, confirm the device receives it.
+
+## Drill 4 — Kiosk post-clockout endpoint failure
+
+**Inject:** temporarily break or slow (>5s) the two kiosk-facing endpoints
+(`GET /bulletins/unread?priority=Urgent`, `GET /people/{personId}/safety/pending`) — e.g. via a
+staging-only fault-injection middleware, or by pointing the Kiosk app's API base URL at a proxy
+that delays/errors those two routes specifically.
+
+**Expect:**
+- The Kiosk app's interstitial auto-advances after 5 seconds (the W2 fallback) instead of hanging
+  — clock-out itself must still succeed and the employee returns to the idle screen.
+- No urgent bulletin or pending safety acknowledgment is silently lost from the *employee's*
+  perspective being blocked — but per Runbook 1 step 5 and the dashboards spec §5, this failure is
+  invisible to the employee by design, which is exactly why server-side alerting on this pair of
+  endpoints matters. Confirm whatever alert/log signal you wired up for these two endpoints (spec
+  §5) actually fires during this drill — if it doesn't fire, the alert isn't correctly configured,
+  not that everything's fine.
+
+**Validates:** Runbook 1 step 5, and the "kiosk interstitial failures" alert in
+`Docs/W6_DASHBOARDS_AND_ALERTS.md` §5. **Fix and confirm:** remove the fault injection, confirm the
+interstitial reliably shows real content again on the next clock-out.
+
+## Drill 5 — Emergency rollback rehearsal
+
+**Inject:** on a staging host with the same `docker compose` topology, deploy a deliberately broken
+commit (e.g. one that throws on startup or 500s on every request), then execute Runbook 4's
+rollback steps verbatim.
+
+**Expect:**
+- `git reset --hard <last-good-sha>` + `docker compose up -d --build mcp api web` restores service
+  within a few minutes.
+- `docker compose ps --filter 'status=running'` shows all 3 services running post-rollback.
+- `/health` and `/health/ready` both report healthy afterward.
+
+**Validates:** Runbook 4 end-to-end. This is the highest-value drill to actually run before
+relying on the rollback runbook during a real incident — the other drills mostly validate
+detection/alerting, this one validates the recovery *mechanism* itself works as written, on this
+specific deployment topology.
+
+## Cadence
+
+Run Drill 5 at least once before the Week 6 go/no-go signoff (it's the one that would be most
+damaging to discover doesn't work during a real incident). Run Drills 1–4 whenever the relevant
+service (DB, S3, push, kiosk endpoints) changes meaningfully, or quarterly at minimum.

--- a/Docs/W6_RUNBOOKS.md
+++ b/Docs/W6_RUNBOOKS.md
@@ -1,0 +1,131 @@
+# W6 Runbooks
+
+**Branch:** `feature/professional-w6-observability` (from `develop`)
+**Plan reference:** `Docs/PROFESSIONAL_DAILY_USE_PLAN.md` — Week 6
+
+These runbooks assume the deployment topology in `.github/workflows/deploy.yml`: a single remote
+host reached over SSH, running `docker compose` with services named `mcp`, `api`, `web` (this
+repo's `ShiftWork.Api` and `ShiftWork.Angular`, plus the MCP server). Deploys happen by SSHing in,
+`git pull origin main`, then `docker compose up -d --build mcp api web`.
+
+---
+
+## Runbook 1 — Degraded API mode
+
+**Trigger:** elevated 5xx rate or p95 latency alert (see `Docs/W6_DASHBOARDS_AND_ALERTS.md` §1–2),
+or `/health` failing.
+
+1. **Confirm scope.** Hit `GET /health` (liveness — process up) and `GET /health/ready`
+   (readiness — DB connectivity, via `ShiftWork.Api/Services/DatabaseHealthCheck.cs`). If `/health`
+   fails, the process is down or unresponsive — skip to step 4. If only `/health/ready` fails, the
+   process is up but the database is unreachable — go to step 2.
+2. **Database unreachable.** Check `DB_CONNECTION_STRING` target is reachable from the host
+   (`Program.cs` throws at startup if this env var is unset, so a missing/wrong value would have
+   already failed the whole deploy — this scenario is a runtime DB outage, not misconfiguration).
+   Check the SQL Server instance's own status/logs. There's no read-replica or fallback DB
+   configured — if the primary is down, the API is fully down for anything touching data (which is
+   everything except `/health`).
+3. **Elevated errors, DB is reachable.** Check application logs for the specific `LogError` calls
+   (every controller wraps its body in try/catch and logs before returning 500 — see
+   `BulletinsController`, `SafetyController`, etc.) to find which endpoint/exception is spiking.
+   Common causes given this codebase: a bad migration left a schema mismatch, a null-reference in
+   a service layer, or a downstream dependency (S3, push, weather API) throwing unhandled — check
+   whether the failing service wraps external calls in try/catch (`WeatherService` is documented
+   as non-blocking / returns null on failure; `AwsS3Service` logs and rethrows in most paths, which
+   an unhandled exception in a controller not expecting it would turn into a 500).
+4. **Process down / unresponsive.** SSH to the host, `docker compose ps` to check container
+   status, `docker compose logs api --tail 200` for the crash reason, `docker compose restart api`.
+   If it crash-loops, go to Runbook 4 (rollback) rather than repeatedly restarting.
+5. **Mitigate user impact while investigating:** the Kiosk app's post-clockout interstitial already
+   auto-advances after 5s on load failure, so clock-in/out itself keeps working even if bulletins/
+   safety endpoints are degraded — prioritize investigating anything touching `POST /api/kiosk/*`
+   or `POST /api/auth/login` over the v2 content endpoints, per the plan's prioritization rule
+   ("protect clocking and payroll-adjacent workflows first").
+
+## Runbook 2 — S3 outage / misconfiguration
+
+**Trigger:** upload/download failures reported for documents, daily-report photos, or bulletin
+attachments; `AwsS3Service` logging `AmazonS3Exception` errors.
+
+1. **Identify the failure mode from logs** — `AwsS3Service` distinguishes:
+   - Bucket not found + `AWS_S3_AUTO_CREATE` disabled → logs
+     `"S3 bucket '{BucketName}' not found in region '{Region}' and auto-create disabled."`
+     This is a config problem (wrong `AWS_S3_BUCKET_NAME` or wrong `AWS_REGION`), not an AWS outage
+     — fix the env var, restart.
+   - `AmazonS3Exception` on upload/download → could be a real AWS outage, a credentials/permission
+     problem (IAM role expired or scoped wrong), or a bucket policy blocking the presigned URL's
+     verb. Check the exception's `StatusCode`/`ErrorCode` in the log — 403 means permissions, 5xx
+     means AWS-side.
+   - Object not found (404) on GET → logged as a `LogWarning`, not an error — this is often a
+     legitimately deleted/never-uploaded object, not an outage signal on its own.
+2. **Confirm scope:** documents, daily-report media, and bulletin attachments all go through the
+   same `IAwsS3Service` — an outage here affects all three uniformly. Employees can still clock in/
+   out and read bulletin/safety text content; only file access is degraded.
+3. **If it's an AWS-side outage:** check the AWS status page for the configured `AWS_REGION`.
+   Nothing to do but wait and communicate — there's no secondary storage provider configured.
+4. **If it's a presigned URL expiry complaint:** by design, GET and PUT URLs expire in 15 minutes
+   (`GeneratePresignedGetUrl`/`GeneratePresignedPutUrl` in `DocumentService.cs`, and the daily
+   report/bulletin upload paths use the same `IAwsS3Service`). A user hitting an expired link
+   should simply re-request; this is not an incident.
+5. **Communicate:** document/photo upload and viewing will be degraded/unavailable; bulletins,
+   safety text, daily report data entry, and clocking are unaffected.
+
+## Runbook 3 — Push notification provider outage
+
+**Trigger:** `PushNotificationService` logging `LogError("Failed to send push notifications...")`
+repeatedly, or employees reporting they aren't receiving bulletin/safety/schedule push alerts.
+
+1. **Confirm it's the provider, not registration.** `LogWarning("No device tokens found for
+   ...")` means the recipient(s) never registered a device token (a mobile app issue, not an
+   outage) — don't treat this as an incident on its own. `LogError` with the Expo response
+   status/body means the Expo Push API itself rejected or failed the batch — that's the real
+   outage signal.
+2. **Check `EXPO_PUSH_API_URL`** is still pointing at the correct endpoint and hasn't been
+   inadvertently changed in the environment config.
+3. **Check Expo's own status page** for the push service.
+4. **Mitigate:** push is the *notification* layer only — the underlying data (bulletins, safety
+   content, schedules) is still created and visible in-app; only the "someone gets pinged" part is
+   degraded. Communicate to managers that time-sensitive bulletins/safety content may need a
+   manual follow-up (call/text) until push recovers, per the "push notifications for all
+   time-sensitive content" UX principle in `CLAUDE.md`.
+5. **After recovery:** there is no current retry/backfill mechanism for missed push sends — anyone
+   who should have been notified during the outage window will need the content surfaced to them
+   some other way (it's still readable in-app; nothing is lost, only the alert).
+
+## Runbook 4 — Emergency rollback
+
+**Trigger:** a bad deploy is confirmed as the cause of an incident (crash loop, data corruption
+risk, security regression) and forward-fixing isn't fast enough.
+
+1. **Identify the last known-good commit on `main`** (the deploy workflow only triggers on pushes
+   to `main`, so this is the branch that matters for rollback).
+2. **Roll back application code:**
+   ```bash
+   ssh <deploy-user>@<deploy-host>
+   cd <project-path>
+   git log --oneline -10          # confirm the bad commit and its parent
+   git reset --hard <last-good-sha>
+   docker compose up -d --build mcp api web
+   docker compose ps --filter 'status=running'   # confirm all 3 services report running
+   ```
+   This mirrors exactly what `.github/workflows/deploy.yml` does on a normal deploy, just pointed
+   at an older commit instead of `HEAD`. Prefer this over `git revert` + re-push through CI if the
+   incident is active — a manual rollback is faster than waiting on a new CI run, but **follow up
+   with a proper `git revert` PR through the normal pipeline once the fire is out**, so `main` and
+   the remote host don't permanently diverge.
+3. **If the bad deploy included an EF Core migration:** check
+   `ShiftWork.Api/Migrations/` for what the last migration touched before rolling back code. Rolling
+   back application code does **not** roll back an already-applied migration. If the new migration
+   is backward-compatible (additive: new nullable column, new table), the old code can usually run
+   against the new schema safely — verify this before rolling back, don't assume it. If the
+   migration was destructive (dropped/renamed a column the old code depends on), rolling back code
+   alone will break — you need `dotnet ef database update <previous-migration-name>` run against
+   production first (high-risk, do this deliberately, not as a reflex).
+4. **Rollback for Mobile/Kiosk (Expo/EAS):** these aren't covered by `deploy.yml` (it explicitly
+   ignores `ShiftWork.Mobile/**` path changes) — mobile releases go through EAS separately (project
+   `531adbf1-53a0-48ca-9fc8-f65ae312365a`, per the W3 summary in
+   `PROFESSIONAL_DAILY_USE_PLAN.md`). Roll back via EAS's own release management, not this repo's
+   git history.
+5. **Post-rollback:** confirm `/health` and `/health/ready` both report healthy, re-check the
+   dashboards in `Docs/W6_DASHBOARDS_AND_ALERTS.md` for the metric that triggered the incident, and
+   open the follow-up `git revert` PR.

--- a/ShiftWork.Api/Program.cs
+++ b/ShiftWork.Api/Program.cs
@@ -16,6 +16,8 @@ using AutoMapper;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 // Load environment variables from .env file
 Env.TraversePath().Load();
@@ -59,6 +61,9 @@ builder.Services.AddDbContext<ShiftWorkContext>((sp, options) =>
     options.UseSqlServer(connectionString);
     options.AddInterceptors(sp.GetRequiredService<AuditInterceptor>());
 });
+
+builder.Services.AddHealthChecks()
+    .AddCheck<DatabaseHealthCheck>("database", tags: new[] { "ready" });
 
 // Add In-Memory Caching service, used by several controllers.
 builder.Services.AddMemoryCache();
@@ -462,5 +467,17 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+
+// Liveness: process is up, no dependency checks.
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    Predicate = _ => false
+});
+
+// Readiness: dependency checks (DB connectivity) tagged "ready".
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready")
+});
 
 app.Run();

--- a/ShiftWork.Api/Services/DatabaseHealthCheck.cs
+++ b/ShiftWork.Api/Services/DatabaseHealthCheck.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using ShiftWork.Api.Data;
+
+namespace ShiftWork.Api.Services
+{
+    public class DatabaseHealthCheck : IHealthCheck
+    {
+        private readonly ShiftWorkContext _context;
+
+        public DatabaseHealthCheck(ShiftWorkContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var canConnect = await _context.Database.CanConnectAsync(cancellationToken);
+                return canConnect
+                    ? HealthCheckResult.Healthy("Database connection is healthy.")
+                    : HealthCheckResult.Unhealthy("Cannot connect to the database.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy("Database health check threw an exception.", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `GET /health` (liveness) and `GET /health/ready` (DB connectivity via a new `DatabaseHealthCheck`) to `ShiftWork.Api` — there were no health-check endpoints at all before this branch.
- `Docs/W6_DASHBOARDS_AND_ALERTS.md` — metric definitions and alert thresholds for API error rate, p95 latency, auth failures, push notification failures, and kiosk interstitial failures, grounded in this codebase's actual structured logging (`PushNotificationService`, `AwsS3Service`, the v2 controllers). No dashboards were actually provisioned — Datadog/Grafana access requires an interactive OAuth grant not available in this session; this doc is the spec for whoever wires up the chosen backend.
- `Docs/W6_RUNBOOKS.md` — degraded API, S3 outage, push provider outage, and emergency rollback, all grounded in the real `docker compose` + SSH deploy flow already in `.github/workflows/deploy.yml` (not a generic template).
- `Docs/W6_FAILURE_DRILLS.md` — 5 concrete drills to validate the above runbooks/alerts actually work. Not executed this session (staging-only); flagged as a pre-signoff follow-up.
- Plan doc (`Docs/PROFESSIONAL_DAILY_USE_PLAN.md`) updated marking Week 6 complete.

## Test plan
- [x] `dotnet build` — clean, no new errors/warnings introduced
- [x] `dotnet test` in `ShiftWork.Api.Tests` — 71/71 passing (no regressions from the health-check wiring)
- [ ] Failure simulation drills (`Docs/W6_FAILURE_DRILLS.md`) — documented but not run against a live staging environment
